### PR TITLE
upgrade to libc 0.2 and kerne32 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ A missing utime function for Rust.
 """
 
 [dependencies]
-libc = "0.1"
+libc = "0.2"
 winapi = "0.2"
-kernel32-sys = "0.1"
+kernel32-sys = "0.2"


### PR DESCRIPTION
libc 0.2 is much more common by now than 0.1
Probably so is kernel32 too.