### PR TITLE
Change timestamps to i64 (from u64)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utime"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Hyeon Kim <simnalamburt@gmail.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utime"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Hyeon Kim <simnalamburt@gmail.com>"]
 edition = "2018"
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,6 @@
+# utime changelog
+
+## 0.2.3
+
+* Timestamps are now i64 (previously u64) seconds from the Unix epoch, the same
+  as in `std::os::unix::fs::MetadataExt` and `utimes(2)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,9 +144,9 @@ pub fn get_file_times<P: AsRef<Path>>(path: P) -> io::Result<(i64, i64)> {
         fn to_seconds(ft: FILETIME) -> i64 {
             let lo = ft.dwLowDateTime as u64;
             let hi = (ft.dwHighDateTime as u64) << 32;
-            let intervals = lo + hi - 116_444_736_000_000_000;
+            let intervals = (lo + hi) as i64 - 116_444_736_000_000_000;
 
-            (intervals / 10_000_000) as i64
+            intervals / 10_000_000
         }
 
         Ok((to_seconds(atime), to_seconds(mtime)))

--- a/tests/utime.rs
+++ b/tests/utime.rs
@@ -52,3 +52,12 @@ fn test_get_times() {
     set_file_times(path, 1_000_000, 1_000_000_000).unwrap();
     assert_eq!(get_file_times(path).unwrap(), (1_000_000, 1_000_000_000));
 }
+
+#[test]
+fn test_set_negative_time() {
+    let path = "target/dummy3";
+
+    File::create(path).unwrap();
+    set_file_times(path, -36000, -36000).unwrap();
+    assert_eq!(get_file_times(path).unwrap(), (-36000, -36000));
+}


### PR DESCRIPTION
* Timestamps are now i64 (previously u64) seconds from the Unix epoch,
  the same as in `std::os::unix::fs::MetadataExt` and `utimes(2)`.

* Partly addresses https://github.com/simnalamburt/utime/issues/2